### PR TITLE
Replace jsxBracketSameLine with bracketSameLine

### DIFF
--- a/four-spaces.js
+++ b/four-spaces.js
@@ -6,6 +6,6 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'all',
   bracketSpacing: true,
-  jsxBracketSameLine: true,
+  bracketSameLine: true,
   arrowParens: 'avoid'
 }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'all',
   bracketSpacing: true,
-  jsxBracketSameLine: true,
+  bracketSameLine: true,
   arrowParens: 'avoid'
 }


### PR DESCRIPTION
`jsxBracketSameLine` was [deprecated](https://prettier.io/blog/2021/09/09/2.4.0.html#replace-jsxbracketsameline-option-with-bracketsameline-option-11006httpsgithubcomprettierprettierpull11006-by-kurtztechhttpsgithubcomkurtztech) in prettier v2.4.0 (September 2021)